### PR TITLE
Bug fix. Use 'loop' outside for-block.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -38,9 +38,9 @@
           </div>
         </div>
       {% endif %}
+      {% if articles_page.has_previous() or loop.length > 1 %}
+        </div>
+      {% endif %}
     {% endfor %}
-    {% if articles_page.has_previous() or loop.length > 1 %}
-      </div>
-    {% endif %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
Will fail if articles_page.has_previous() == False. Because `loop` is referenced outside for-block.