### PR TITLE
fix end of loop logic for new jinja2 behavior

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -18,12 +18,14 @@
           <h2 class="subtitle">Other articles</h2>
           {% include 'pagination.html' %}
           <div class="columns is-multiline">
+          {% set needenddiv = true %}
         {% endif %}
       {% else %}
         {% if loop.first %}
           <h2 class="subtitle">Other articles</h2>
           {% include 'pagination.html' %}
           <div class="columns is-multiline">
+          {% set needenddiv = true %}
         {% endif %}
         <div class="column is-half-tablet is-one-third-desktop">
           <div class="card is-fullwidth is-fullheight">
@@ -39,7 +41,7 @@
         </div>
       {% endif %}
     {% endfor %}
-    {% if articles_page.has_previous() or loop.length > 1 %}
+    {% if articles_page.has_previous() or needenddiv %}
       </div>
     {% endif %}
   {% endif %}


### PR DESCRIPTION
Trying to use this with whatever is "latest and greatest", I was getting a jinja2 error 

```
pelican ./content -o ./public -s ./pelicanconf.py  --relative-urls                                                           
WARNING: JINJA_EXTENSIONS setting has been deprecated, moving it to JINJA_ENVIRONMENT setting.                               
WARNING: Feeds generated without SITEURL set properly may not be valid                                                       
CRITICAL: UndefinedError: 'loop' is undefined                                                                                
Traceback (most recent call last):                                                                                           
  File "C:\Users\Jerry\venv\py2\Scripts\pelican-script.py", line 11, in <module>                                             
    load_entry_point('pelican', 'console_scripts', 'pelican')()                                                              
  File "c:\users\jerry\d\workspace\pelican\pelican\__init__.py", line 487, in main                                           
    pelican.run()                                                                                                            
  File "c:\users\jerry\d\workspace\pelican\pelican\__init__.py", line 179, in run                                            
    p.generate_output(writer)                                                                                                
  File "c:\users\jerry\d\workspace\pelican\pelican\generators.py", line 615, in generate_output                              
    self.generate_pages(writer)                                                                                              
  File "c:\users\jerry\d\workspace\pelican\pelican\generators.py", line 511, in generate_pages                               
    self.generate_direct_templates(write)                                                                                    
  File "c:\users\jerry\d\workspace\pelican\pelican\generators.py", line 459, in generate_direct_templates                    
    page_name=os.path.splitext(save_as)[0])                                                                                  
  File "c:\users\jerry\d\workspace\pelican\pelican\writers.py", line 224, in write_file                                      
    page.save_as, override_output)                                                                                           
  File "c:\users\jerry\d\workspace\pelican\pelican\writers.py", line 171, in _write_file                                     
    output = template.render(localcontext)                                                                                   
  File "c:\users\jerry\venv\py2\lib\site-packages\jinja2\environment.py", line 1008, in render                               
    return self.environment.handle_exception(exc_info, True)                                                                 
  File "c:\users\jerry\venv\py2\lib\site-packages\jinja2\environment.py", line 780, in handle_exception                      
    reraise(exc_type, exc_value, tb)                                                                                         
  File "C:\users\jerry\d\workspace\ashercodes\themes\bulrush\templates\index.html", line 1, in top-level template code       
    {% extends "base.html" %}                                                                                                
  File "C:\users\jerry\d\workspace\ashercodes\themes\bulrush\templates\base.html", line 60, in top-level template code       
    {% block content %}                                                                                                      
  File "C:\users\jerry\d\workspace\ashercodes\themes\bulrush\templates\index.html", line 42, in block "content"              
    {% if articles_page.has_previous() or loop.length > 1 %}                                                                 
  File "c:\users\jerry\venv\py2\lib\site-packages\jinja2\environment.py", line 430, in getattr                               
    return getattr(obj, attribute)                                                                                           
jinja2.exceptions.UndefinedError: 'loop' is undefined                                                                        
make: *** [Makefile:68: html] Error 1                                                                                        
```

I believe the problem is in index.html which relies on old, incorrect, jinja2 behavior:

http://jinja.pocoo.org/docs/2.9/templates/

>The loop variable always refers to the closest (innermost) loop. If we have more than one level of loops, we can rebind the variable loop by writing {% set outer_loop = loop %} after the loop that we want to use recursively. Then, we can call it using {{ outer_loop(...) }}

>Please note that assignments in loops will be cleared at the end of the iteration and cannot outlive the loop scope. Older versions of Jinja2 had a bug where in some circumstances it appeared that assignments would work. This is not supported. See Assignments for more information about how to deal with this.

I think the attach patch should fix this.