### PR TITLE
Custom css support

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
   {% endassets %}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.3.0/css/bulma.min.css">
+  <link rel="stylesheet" href="{{ SITEURL }}/{{ CUSTOM_CSS }}">
   <!--[if IE]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->


### PR DESCRIPTION
By adding this change, one is able to easily load custom css files by doing something like the following:

```python 
STATIC_PATHS = ['images', 'static/custom.css']
EXTRA_PATH_METADATA = {
    'static/custom.css': {'path': 'static/custom.css'}
}```