### PR TITLE
Update JustNumbersAndThings URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Here are few current users of Bulrush (or modified versions of it):
  - [Simon Says](https://simonsays.neocities.org/)
  - [CodeRobot](http://coderobot.downley.net/)
  - [chair6.net](http://chair6.net/)
- - [Numbers and Things](http://ryanarichmond.com/)
+ - [Just Numbers and Things](http://justnumbersandthings.com/)
 
 If you'd like to be featured here (or are and would prefer not to be), feel
 free to submit a [pull request][18].


### PR DESCRIPTION
Cool Theme!

Unrelated question is there a config to make it so the homepage only shows a summary of the latest post instead of the post in its entirety ?

Edit: The real reason I ask is because comments don't show on the homepage however after reviewing your homepage I noticed that you had a Nice `# Comment` at the bottom. Is there a config on disqus that I missed somewhere?

Edit2: Ah you updated the theme.. the config option mentioned above would still be cool but anyways this looks great thanks!