### PR TITLE
Page menu fixes

### DIFF
--- a/templates/article_list.html
+++ b/templates/article_list.html
@@ -1,7 +1,6 @@
 {% if article_list %}
   <div class="is-hidden-print">
     <h2 class="subtitle">Other articles</h2>
-    {% include 'pagination.html' %}
     <div class="columns is-multiline">
       {% for article in article_list %}
         <div class="column is-half-tablet is-one-third-desktop">

--- a/templates/article_list.html
+++ b/templates/article_list.html
@@ -18,5 +18,6 @@
         </div>
       {% endfor %}
     </div>
+    {% include 'pagination.html' %}
   </div>
 {% endif %}

--- a/templates/meta_tags.html
+++ b/templates/meta_tags.html
@@ -1,4 +1,4 @@
-<meta property="og:title" content="{{ SITENAME }}{% if item.title %} - {{ item.title }}{% endif %}">
+<meta property="og:title" content="{{ SITENAME }}{% if item.title %} - {{ item.title|striptags }}{% endif %}">
 {% if item.summary %}
   <meta property="og:description" content="{{ item.summary | striptags | truncate(200, end='...') }}">
 {% endif %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ page.title }}{% endblock %}
+{% block title %}{{ page.title|striptags }}{% endblock %}
 {% block tags %}
   {% with item=page %}
     {% include 'meta_tags.html' %}

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -1,12 +1,26 @@
 <nav class="pagination is-centered">
-  <a class="pagination-previous{% if not articles_page.has_previous() %} is-disabled{% endif %}"
+  {% if articles_page.has_previous() %}
+    <a class="pagination-previous"
       href="{{ SITEURL }}/{{ articles_previous_page.url }}">
     Previous
   </a>
-  <a class="pagination-next{% if not articles_page.has_next() %} is-disabled{% endif %}"
-      href="{{ SITEURL }}/{{ articles_next_page.url }}">
-    Next page
+  {% else %}
+    <a class="pagination-previous is-disabled"
+      href="#">
+    Previous
   </a>
+  {% endif %}
+  {% if articles_page.has_next() %}
+    <a class="pagination-next"
+        href="{{ SITEURL }}/{{ articles_next_page.url }}">
+      Next page
+    </a>
+  {% else %}
+    <a class="pagination-next is-disabled"
+        href="#">
+      Next page
+    </a>
+  {% endif %}
   <ul class="pagination-list">
     <li>Page {{ articles_page.number }} / {{ articles_paginator.num_pages }}</li>
   </ul>


### PR DESCRIPTION
These commits strip the HTML tags from page titles, and has the next and previous page links point to the current page rather than the home page, when there are no further pages of articles to see