### PR TITLE
remove badge from Bulma.io that was leaving cookie

### DIFF
--- a/bulrush/templates/base.html
+++ b/bulrush/templates/base.html
@@ -128,7 +128,7 @@
         <a href="https://blog.getpelican.com/">Pelican</a></span>
       <span><span class="icon is-small"><i class="fa fa-html5"></i></span> HTML 5</span>
       <span><span class="icon is-small"><i class="fa fa-css3"></i></span> CSS 3</span>
-      <img class="badge" src="https://bulma.io/images/made-with-bulma--black.png">
+      <span>Made with <a href="https://bulma.io">Bulma</a></span>
     </div>
   </div>
   {% include 'github.html' %}


### PR DESCRIPTION
based on this issue
https://github.com/textbook/bulrush/issues/20

I removed the link to the bulma.io hosted badge, which was leaving a cookie on the user's machine.
I've replaced with "Made with Bulma" with a link to bulma.io