### PR TITLE
Add exclude option for css files

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,21 @@ EXTRA_PATH_METADATA = {
 }
 ```
 
+CSS files can also be prevented from being included in the base template by
+adding and an `exclude` key-value pair. For example, in your `pelicanconf.py`:
+
+```python
+# Static files
+STATIC_PATHS = [
+    'extra',
+    ...
+]
+EXTRA_PATH_METADATA = {
+    'extra/custom.css': {'path': 'custom.css', 'exclude': True},
+    ...
+}
+```
+
 In use
 ------
 

--- a/bulrush/templates/base.html
+++ b/bulrush/templates/base.html
@@ -11,7 +11,7 @@
   {% endassets %}
   <style media="print">.is-hidden-print{display:none !important}</style>
   {% for extra_path in EXTRA_PATH_METADATA.values() %}
-    {% if extra_path.get('path', '').endswith('.css') %}
+    {% if extra_path.get('path', '').endswith('.css') and not extra_path.get('exclude', False)%}
       <link rel="stylesheet" href="{{ SITEURL }}/{{ extra_path['path'] }}">
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
I have a somewhat unusual use case in that I have CSS files that I don't want all CSS files included everywhere in the site which is the current behavior of bulrush. This PR allows the exclusion of CSS files that were added to the `EXTRA_PATH_METADATA` dict to be ignored if an `'exclude': True` key-value pair is added. If that key-value pair isn't added then the theme operates as before.